### PR TITLE
Setup CI (Devcontainer Flavor)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,7 +42,7 @@
     // "forwardPorts": [],
 
     // Use 'postCreateCommand' to run commands after the container is created.
-    "postCreateCommand": "swift --version && sudo ./Tools/make-pkgconfig.sh",
+    "postCreateCommand": "swift --version && sudo ./Tools/make-pkgconfig.sh /usr/local/lib/pkgconfig/llvm.pc",
 
     // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
     "remoteUser": "vscode"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,18 +65,15 @@ jobs:
       run: llvm-config --version
 
     - name: Configure pkgconfig
-      if: ${{ !matrix.host.uses-devcontainer }}
       run: sudo ./Tools/make-pkgconfig.sh
 
     - name: Build (Debug)
-      if: ${{ !matrix.host.uses-devcontainer }}
       run: swift build -v -c debug
 
     - name: Test (Debug)
       run: swift test -v -c debug ${{ matrix.host.test-options }}
 
     - name: Build (Release)
-      if: ${{ !matrix.host.uses-devcontainer }}
       run: swift build -v -c release
 
     - name: Test (Release)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build-devcontainer:
-    name: Swift 5 on ${{ matrix.host.os }} using .devcontainer
+    name: Test ${{ matrix.configuration }} on ${{ matrix.host.os }} using .devcontainer
     strategy: 
       fail-fast: false
       matrix: 
@@ -33,13 +33,12 @@ jobs:
     - run: git config --global core.autocrlf input
 
     - name: Build and run devcontainer task
-      if: matrix.host.uses-devcontainer
       uses: devcontainers/ci@v0.3
       with:
         runCmd: swift test -v -c ${{ matrix.configuration }} ${{ matrix.host.test-options }}
 
   build-native:
-    name: Swift 5 on ${{ matrix.host.os }} natively
+    name: Test ${{ matrix.configuration }} on ${{ matrix.host.os }} natively
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,11 @@ on:
 jobs:
   build-devcontainer:
     name: Swift 5 on ${{ matrix.host.os }} using .devcontainer
-    strategy: fail-fast: false
-    matrix: [
-      { type: linux, os: ubuntu-latest, test-options: --enable-code-coverage, }
-    ]
+    strategy: 
+      fail-fast: false
+      matrix: [
+        { type: linux, os: ubuntu-latest, test-options: --enable-code-coverage, }
+      ]
 
     runs-on: ${{ matrix.host.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
     - run: llvm-config --version
 
     - name: Configure pkgconfig
-      run: sudo ./Tools/make-pkgconfig.sh
+      run: sudo ./Tools/make-pkgconfig.sh /usr/local/lib/pkgconfig/llvm.pc
 
     - name: Build
       run: swift build -v -c ${{ matrix.configuration }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,11 @@ jobs:
     name: Swift 5 on ${{ matrix.host.os }} using .devcontainer
     strategy: 
       fail-fast: false
-      matrix: [
-        { type: linux, os: ubuntu-latest, test-options: --enable-code-coverage, }
-      ]
+      matrix: 
+        host: [
+          { type: linux, os: ubuntu-latest, test-options: --enable-code-coverage, }
+        ]
+        configuration: [ "debug", "release" ]
 
     runs-on: ${{ matrix.host.os }}
     steps:
@@ -34,9 +36,7 @@ jobs:
       if: matrix.host.uses-devcontainer
       uses: devcontainers/ci@v0.3
       with:
-        runCmd: |
-          swift test -v -c debug ${{ matrix.host.test-options }}
-          swift test -v -c release ${{ matrix.host.test-options }}
+        runCmd: swift test -v -c ${{ matrix.configuration }} ${{ matrix.host.test-options }}
 
   build-native:
     name: Swift 5 on ${{ matrix.host.os }} natively
@@ -46,6 +46,7 @@ jobs:
         host: [
           { type: macos, os: macos-latest}
         ]
+        configuration: [ "debug", "release" ]
 
     runs-on: ${{ matrix.host.os }}
     steps:
@@ -63,23 +64,17 @@ jobs:
       uses: KyleMayes/install-llvm-action@v1
       with:
         version: "15.0"
-        
+
     - run: llvm-config --version
 
     - name: Configure pkgconfig
       run: sudo ./Tools/make-pkgconfig.sh
 
-    - name: Build (Debug)
-      run: swift build -v -c debug
+    - name: Build
+      run: swift build -v -c ${{ matrix.configuration }}
 
-    - name: Test (Debug)
-      run: swift test -v -c debug ${{ matrix.host.test-options }}
-
-    - name: Build (Release)
-      run: swift build -v -c release
-
-    - name: Test (Release)
-      run: swift test -c release -Xswiftc -enable-testing ${{ matrix.host.test-options }}
+    - name: Test 
+      run: swift test -v -c ${{ matrix.configuration }} ${{ matrix.host.test-options }}
 
 
   

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,8 @@ jobs:
     steps:
     - name: Checkout (GitHub)
       uses: actions/checkout@v3
-      run: | 
-        git config --global core.autocrlf input
+
+    - run: git config --global core.autocrlf input
 
     - name: Build and run devcontainer task
       if: matrix.host.uses-devcontainer
@@ -51,18 +51,20 @@ jobs:
     steps:
     - name: Checkout (GitHub)
       uses: actions/checkout@v3
-      run: | 
-        git config --global core.autocrlf input
+
+    - run: git config --global core.autocrlf input
 
     - name: Setup Swift
       uses: swift-actions/setup-swift@v1
-      run: swift --version
+
+    - run: swift --version
       
     - name: Install LLVM
       uses: KyleMayes/install-llvm-action@v1
       with:
         version: "15.0"
-      run: llvm-config --version
+        
+    - run: llvm-config --version
 
     - name: Configure pkgconfig
       run: sudo ./Tools/make-pkgconfig.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build-devcontainer:
-    name: Test ${{ matrix.configuration }} on ${{ matrix.host.os }} using .devcontainer
+    name: "Devcontainer: ${{ matrix.host.os }}/${{ matrix.configuration }}"
     strategy: 
       fail-fast: false
       matrix: 
@@ -38,7 +38,7 @@ jobs:
         runCmd: swift test -v -c ${{ matrix.configuration }} ${{ matrix.host.test-options }}
 
   build-native:
-    name: Test ${{ matrix.configuration }} on ${{ matrix.host.os }} natively
+    name: "Native: ${{ matrix.host.os }}/${{ matrix.configuration }}"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,3 @@ jobs:
 
     - name: Test 
       run: swift test -v -c ${{ matrix.configuration }} ${{ matrix.host.test-options }}
-
-
-  
-  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,27 +15,72 @@ on:
       - ".gitignore"
 
 jobs:
-  build:
-    name: Swift 5 on ${{ matrix.host.os }}
+  build-devcontainer:
+    name: Swift 5 on ${{ matrix.host.os }} using .devcontainer
+    strategy: fail-fast: false
+    matrix: [
+      { type: linux, os: ubuntu-latest, test-options: --enable-code-coverage, }
+    ]
+
+    runs-on: ${{ matrix.host.os }}
+    steps:
+    - name: Checkout (GitHub)
+      uses: actions/checkout@v3
+      run: | 
+        git config --global core.autocrlf input
+
+    - name: Build and run devcontainer task
+      if: matrix.host.uses-devcontainer
+      uses: devcontainers/ci@v0.3
+      with:
+        runCmd: |
+          swift test -v -c debug ${{ matrix.host.test-options }}
+          swift test -v -c release ${{ matrix.host.test-options }}
+
+  build-native:
+    name: Swift 5 on ${{ matrix.host.os }} natively
     strategy:
       fail-fast: false
       matrix:
         host: [
-          { type: linux, os: ubuntu-latest, test-options: --enable-code-coverage, }
+          { type: macos, os: macos-latest}
         ]
+
     runs-on: ${{ matrix.host.os }}
     steps:
+    - name: Checkout (GitHub)
+      uses: actions/checkout@v3
+      run: | 
+        git config --global core.autocrlf input
 
-      - name: Checkout (GitHub)
-        uses: actions/checkout@v3
-
-      - name: Build and run devcontainer task
-        uses: devcontainers/ci@v0.3
-        with:
-          runCmd: swift test
-
+    - name: Setup Swift
+      uses: swift-actions/setup-swift@v1
+      run: swift --version
       
+    - name: Install LLVM
+      uses: KyleMayes/install-llvm-action@v1
+      with:
+        version: "15.0"
+      run: llvm-config --version
+
+    - name: Configure pkgconfig
+      if: ${{ !matrix.host.uses-devcontainer }}
+      run: sudo ./Tools/make-pkgconfig.sh
+
+    - name: Build (Debug)
+      if: ${{ !matrix.host.uses-devcontainer }}
+      run: swift build -v -c debug
+
+    - name: Test (Debug)
+      run: swift test -v -c debug ${{ matrix.host.test-options }}
+
+    - name: Build (Release)
+      if: ${{ !matrix.host.uses-devcontainer }}
+      run: swift build -v -c release
+
+    - name: Test (Release)
+      run: swift test -c release -Xswiftc -enable-testing ${{ matrix.host.test-options }}
 
 
-    
-    
+  
+  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: Test
+
+on:
+  push:
+    branches: [ main, rewrite ]
+    paths-ignore:
+      - "**.md"
+      - "LICENSE"
+      - ".gitignore"
+  pull_request:
+    branches: [ "**" ]
+    paths-ignore:
+      - "**.md"
+      - "LICENSE"
+      - ".gitignore"
+
+jobs:
+  build:
+    name: Swift 5 on ${{ matrix.host.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        host: [
+          { type: linux, os: ubuntu-latest, test-options: --enable-code-coverage, }
+        ]
+    runs-on: ${{ matrix.host.os }}
+    steps:
+
+      - name: Checkout (GitHub)
+        uses: actions/checkout@v3
+
+      - name: Build and run devcontainer task
+        uses: devcontainers/ci@v0.3
+        with:
+          runCmd: swift test
+
+      
+
+
+    
+    

--- a/Tools/make-pkgconfig.sh
+++ b/Tools/make-pkgconfig.sh
@@ -6,11 +6,19 @@ filename=$1
 mkdir -p `dirname $filename`
 touch $filename
 
+# REVISIT: Why does macos need the standard library explicitly linked, while linux does not?
+# This does not feel like the correct place for this logic.
+machine="$(uname -s)"
+case "${machine}" in
+  Darwin*)  libs="-lc++";;
+  *)        libs=""
+esac
+
 echo Name: LLVM > $filename
 echo Description: Low-level Virtual Machine compiler framework >> $filename
 echo Version: $(echo ${version} | sed 's/\([0-9.]\+\).*/\1/') >> $filename
 echo URL: http://www.llvm.org/ >> $filename
-echo Libs: -L$(llvm-config --libdir --system-libs --libs core analysis) >> $filename
+echo Libs: ${libs} -L$(llvm-config --libdir --system-libs --libs core analysis) >> $filename
 echo Cflags: -I$(llvm-config --includedir) >> $filename
 
 echo "$filename written:"

--- a/Tools/make-pkgconfig.sh
+++ b/Tools/make-pkgconfig.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 version=$(llvm-config --version)
-filename=/usr/local/lib/pkgconfig/llvm.pc
+filename=$1
 
 mkdir -p `dirname $filename`
 touch $filename
@@ -12,3 +12,6 @@ echo Version: $(echo ${version} | sed 's/\([0-9.]\+\).*/\1/') >> $filename
 echo URL: http://www.llvm.org/ >> $filename
 echo Libs: -L$(llvm-config --libdir --system-libs --libs core analysis) >> $filename
 echo Cflags: -I$(llvm-config --includedir) >> $filename
+
+echo "$filename written:"
+cat $filename

--- a/Tools/make-pkgconfig.sh
+++ b/Tools/make-pkgconfig.sh
@@ -6,7 +6,8 @@ filename=$1
 mkdir -p `dirname $filename`
 touch $filename
 
-# REVISIT: Why does macos need the standard library explicitly linked, while linux does not?
+# REVISIT(nickpdemarco):
+# Why does macos need the standard library explicitly linked, while linux does not?
 # This does not feel like the correct place for this logic.
 machine="$(uname -s)"
 case "${machine}" in

--- a/Tools/make-pkgconfig.sh
+++ b/Tools/make-pkgconfig.sh
@@ -19,7 +19,7 @@ echo Name: LLVM > $filename
 echo Description: Low-level Virtual Machine compiler framework >> $filename
 echo Version: $(echo ${version} | sed 's/\([0-9.]\+\).*/\1/') >> $filename
 echo URL: http://www.llvm.org/ >> $filename
-echo Libs: -L$(llvm-config --libdir --system-libs --libs analysis bitwriter core native target) >> $filename
+echo Libs: ${libs} -L$(llvm-config --libdir --system-libs --libs analysis bitwriter core native target) >> $filename
 echo Cflags: -I$(llvm-config --includedir) >> $filename
 
 echo "$filename written:"


### PR DESCRIPTION
This PR enables Continuous Integration for Swifty-LLVM. It uses two distinct approaches:

1. Build Linux using the .devcontainer configuration
2. Build macOS using standard GitHub actions tasks

This fragmentation was chosen for the following benefits:

1. We now have a single configuration for Linux (defined in `.devcontainer/Dockerfile`), which models the ideal setup instructions for Linux users. Debugging Linux CI is now as simple as running a devcontainer in VSCode. 
2. If we're willing to host our devcontainer image (say, on ghcr.io), the environment setup (dominated by downloading LLVM) will be nearly instantaneous. 