### PR TITLE
Make Windows use Swift 5.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
           { type: windows, os: windows-latest },
         ]
         swift: [
-          { windows-branch: "development", windows-tag: "DEVELOPMENT-SNAPSHOT-2023-04-01-a" }
+          { windows-branch: "swift-5.8-release", windows-tag: "5.8-RELEASE" }
         ]
     runs-on: ${{ matrix.host.os }}
     steps:


### PR DESCRIPTION
We need to use a more stable version with no unexpected errors, and developing version does not have a significant positive impact on our CI