### PR TITLE
Make make-pkgconfig.sh search for libzstd.a properly

### DIFF
--- a/Tools/make-pkgconfig.sh
+++ b/Tools/make-pkgconfig.sh
@@ -20,7 +20,7 @@ echo Name: LLVM > $filename
 echo Description: Low-level Virtual Machine compiler framework >> $filename
 echo Version: $(echo ${version} | sed 's/\([0-9.]\+\).*/\1/') >> $filename
 echo URL: http://www.llvm.org/ >> $filename
-echo Libs: ${libs} -L$(llvm-config --libdir --system-libs --libs analysis bitwriter core native passes target) >> $filename
+echo Libs: -L$(llvm-config --libdir) $(pkg-config --libs-only-L libzstd) ${libs} $(llvm-config --system-libs --libs analysis bitwriter core native passes target) >> $filename
 echo Cflags: -I$(llvm-config --includedir) >> $filename
 
 echo "$filename written:"


### PR DESCRIPTION
Using pkg-config, add a -L library search path for libzstd.a.