### PR TITLE
Simplify pkg-config by removing libzstd dependency trial

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,8 @@
-// swift-tools-version: 6.1
-import PackageDescription
-
-
 // BEGIN: Poor person's pkg-config processing, since SPM doesn't
 // fully understand pkg-config files on Windows.
 import Foundation
+// swift-tools-version: 6.1
+import PackageDescription
 
 #if os(Windows)
   let osIsWindows = true
@@ -24,7 +22,9 @@ func pseudoPkgConfigText(_ package: String) -> String? {
   guard let pcp = ProcessInfo.processInfo.environment["PKG_CONFIG_PATH"] else { return nil }
 
   return pcp.split(separator: pathSeparator)
-    .lazy.compactMap({ try? String(contentsOfFile: "\($0)/\(package).pc", encoding: String.Encoding.utf8) }).first
+    .lazy.compactMap({
+      try? String(contentsOfFile: "\($0)/\(package).pc", encoding: String.Encoding.utf8)
+    }).first
 }
 
 /// Returns the un-quoted, un-escaped elements in the remainder of the
@@ -34,7 +34,8 @@ func pkgConfigValues(in pcFileText: String, for key: String) -> [String] {
   let keyPattern = NSRegularExpression.escapedPattern(for: key)
   let lineHeaders = pcFileText.matches(
     forRegex: #"(?m)(?<!\\[\r]?[\n])^[ \t]*"# + keyPattern
-      + #"[ \t]*:[ \t]*"#).joined().compactMap { $0 }
+      + #"[ \t]*:[ \t]*"#
+  ).joined().compactMap { $0 }
 
   var r: [String] = []
 
@@ -47,13 +48,11 @@ func pkgConfigValues(in pcFileText: String, for key: String) -> [String] {
       open = true
     }
 
-    header:
-      while let c = input.popFirst(), !c.isNewline {
+    header: while let c = input.popFirst(), !c.isNewline {
       switch c {
       case "'", "\"":
         let quote = c
-        quoting:
-          while let c1 = input.popFirst() {
+        quoting: while let c1 = input.popFirst() {
           switch c1 {
           case "\\":
             if let c2 = input.popFirst() { add(c2) }
@@ -84,7 +83,7 @@ extension String {
       range: NSRange(startIndex..<endIndex, in: self)
     ).map { m in
       groups.map { g in
-        Range(m.range(at: g), in: self).map { self[ $0 ] }
+        Range(m.range(at: g), in: self).map { self[$0] }
       }
     }
   }
@@ -101,7 +100,8 @@ func windowsLinkerSettings() -> [LinkerSetting] {
   let libs = pkgConfigValues(in: t, for: "Libs")
   let linkLibraries = libs.lazy.filter { $0.starts(with: "-l") || $0.first != "-" }.map {
     let rest = $0.dropFirst($0.first == "-" ? 2 : 0)
-    let afterSlashes = rest.lastIndex(where: { $0 == "/" || $0 == "\\" })
+    let afterSlashes =
+      rest.lastIndex(where: { $0 == "/" || $0 == "\\" })
       .map { rest.index(after: $0) } ?? rest.startIndex
     return rest[afterSlashes...]
   }
@@ -114,12 +114,17 @@ func windowsLinkerSettings() -> [LinkerSetting] {
   return libNames
 }
 
-let llvmLinkerSettings = osIsWindows ? windowsLinkerSettings() : []
+let llvmLinkerSettings =
+  osIsWindows
+  ? windowsLinkerSettings()
+  : [
+    .unsafeFlags(["-L/opt/homebrew/lib"], .when(platforms: [.macOS]))
+  ]
 
 let package = Package(
   name: "Swifty-LLVM",
   products: [
-    .library(name: "SwiftyLLVM", targets: ["SwiftyLLVM"]),
+    .library(name: "SwiftyLLVM", targets: ["SwiftyLLVM"])
   ],
   targets: [
     // LLVM API Wrappers.

--- a/Tools/make-pkgconfig.sh
+++ b/Tools/make-pkgconfig.sh
@@ -2,20 +2,6 @@
 set -e
 set -o pipefail
 
-# Work around https://github.com/hylo-lang/llvm-build/issues/8
-#
-# We need to be resilient to no libzstd being found by pkg-config, as it is apparently not on linux.
-zstd_dash_L="$(pkg-config --silence-errors --libs-only-L libzstd || true)"
-if ! (llvm-config > /dev/null 2>&1); then
-  if [[ "$OSTYPE" == "linux-gnu"* || "$OSTYPE" == "cygwin" || "$OSTYPE" == "freebsd"* ]]; then
-    export LD_LIBRARY_PATH="${zstd_dash_L#-L}:$LD_LIBRARY_PATH"
-  elif [[ "$OSTYPE" == "darwin"* ]]; then
-    export DYLD_LIBRARY_PATH="${zstd_dash_L#-L}:$DYLD_LIBRARY_PATH"
-  elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
-    export PATH="${zstd_dash_L#-L}:$PATH"
-  fi
-fi
-
 version=$(llvm-config --version)
 filename=$1
 
@@ -32,7 +18,7 @@ case "${machine}" in
 esac
 
 libs=()
-for x in -L$(llvm-config --libdir) ${zstd_dash_L} $(llvm-config --system-libs --libs analysis bitwriter core native passes target); do
+for x in -L$(llvm-config --libdir) $(llvm-config --system-libs --libs analysis bitwriter core native passes target); do
     libs+=($(printf '%q' "$x"))
 done
 cflags=()


### PR DESCRIPTION
The problem was that the homebrew library installation folder wasn't added to the library search path in SPM on MacOS. Adding the flag fixes the issue.