### PR TITLE
Add fallback library search paths to find zstd

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,12 +159,14 @@ jobs:
         with:
           swift-version: ${{ env.swift-version }}
 
-      - name: Install Swift-compatible Visual Studio Toolchain (Windows)
+      - name: Download Recent Visual Studio and Windows SDK
         uses: compnerd/gha-setup-vsdevenv@main
         with:
-          winsdk: "10.0.22621.0" # Workaround for this: https://forums.swift.org/t/swiftpm-plugin-doesnt-work-with-the-latest-visual-studio-version/78183/14
-          # TL;DR: The Windows SDK had a change in 10.0.26100.0 that the Swift compiler didn't account for.
-          # The Swift compiler team is aware of the issue and they are going to release a fix some time.
+          winsdk: "10.0.26100.0"
+          # Note: The GitHub windows-2025 runner has only a very old version of the Windows SDK available by default.
+          #       Swift is said to require version 10.0.22621.0: https://forums.swift.org/t/swiftpm-plugin-doesnt-work-with-the-latest-visual-studio-version/78183/14
+          #       That no longer works, so we had to upgrade to 10.0.26100.0.
+          #       See also: https://github.com/swiftlang/swift/issues/88237
 
       - name: SPM Cache Setup
         uses: actions/cache@v4.2.4
@@ -236,12 +238,14 @@ jobs:
         with:
           swift-version: ${{ env.swift-version }}
 
-      - name: Install Swift-compatible Visual Studio Toolchain (Windows)
+      - name: Download Recent Visual Studio and Windows SDK
         uses: compnerd/gha-setup-vsdevenv@main
         with:
-          winsdk: "10.0.22621.0" # Workaround for this: https://forums.swift.org/t/swiftpm-plugin-doesnt-work-with-the-latest-visual-studio-version/78183/14
-          # TL;DR: The Windows SDK had a change in 10.0.26100.0 that the Swift compiler didn't account for.
-          # The Swift compiler team is aware of the issue and they are going to release a fix some time.
+          winsdk: "10.0.26100.0"
+          # Note: The GitHub windows-2025 runner has only a very old version of the Windows SDK available by default.
+          #       Swift is said to require version 10.0.22621.0: https://forums.swift.org/t/swiftpm-plugin-doesnt-work-with-the-latest-visual-studio-version/78183/14
+          #       That no longer works, so we had to upgrade to 10.0.26100.0.
+          #       See also: https://github.com/swiftlang/swift/issues/88237
 
       - name: Configure (CMake)
         # We explicitly point to swiftc in the PATH because otherwise CMake picks up the one in XCode.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ env:
   spm-build-options: -Xswiftc -enable-testing --explicit-target-dependency-import-check error
   spm-test-options: --parallel
   swift-version: '6.2'
-  HYLO_LLVM_BUILD_RELEASE: 20251018-115119
+  HYLO_LLVM_BUILD_RELEASE: 20260521-114955
   HYLO_LLVM_VERSION: '20.1.6'
 
 jobs:

--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,8 @@ func findExecutableOnPath(name: String) -> String? {
   return nil
 }
 
-/// Returns the contents written to the standard output by `executable` ran with `arguments`.
+/// Returns the contents written to the standard output by `executable` ran with `arguments`, or
+/// `nil` on failure.
 func readProcessOutput(executable: String, arguments: [String]) -> String? {
   let process = Process()
   process.executableURL = URL(fileURLWithPath: executable)

--- a/Package.swift
+++ b/Package.swift
@@ -29,10 +29,10 @@ func pkgConfigContents(_ package: String) -> String? {
 
 /// Returns the un-quoted, un-escaped elements in the remainder of the (logical) lines beginning
 /// with `"\(key): "` in `pcContents`, which are the contents of a pkg-config file.
-func pkgConfigValues(in pcContents: String, for key: String) -> [String] {
+func pkgConfigValues(in pcContents: String, for key: String) throws -> [String] {
   let keyPattern = NSRegularExpression.escapedPattern(for: key)
   let lineHeadersPattern = #"(?m)(?<!\\[\r]?[\n])^[ \t]*"# + keyPattern + #"[ \t]*:[ \t]*"#
-  let lineHeaders = pcContents.matches(forRegex: lineHeadersPattern).joined().compactMap { $0 }
+  let lineHeaders = try pcContents.matches(forRegex: lineHeadersPattern).joined().compactMap { $0 }
 
   var r: [String] = []
   for h in lineHeaders {
@@ -69,8 +69,8 @@ extension String {
 
   /// Returns, for each match of the valid regular expression `pattern`, the given match `groups`
   /// in the same order in which they were passed.
-  func matches(forRegex pattern: String, groups: [Int] = [0]) -> [[Substring?]] {
-    let r = try! NSRegularExpression(pattern: pattern)
+  func matches(forRegex pattern: String, groups: [Int] = [0]) throws -> [[Substring?]] {
+    let r = try NSRegularExpression(pattern: pattern)
     return r.matches(in: self, range: NSRange(startIndex..<endIndex, in: self)).map { m in
       groups.map { g in Range(m.range(at: g), in: self).map { self[ $0 ] } }
     }
@@ -87,31 +87,45 @@ extension Substring {
 
 }
 
+extension Optional {
+
+  /// Returns the value wrapped in `optional` or calls `trap` if `optional` is `nil`.
+  public static func ?? (optional: Self, trap: @autoclosure () -> Never) -> Wrapped {
+    if let wrapped = optional { wrapped } else { trap() }
+  }
+
+}
+
 // MARK: Helpers for getting flags and other settings
 
 /// Returns the linker needed for building on Windows.
 func windowsLinkerSettings() -> [LinkerSetting] {
-  guard let t = pkgConfigContents("llvm") else { return [] }
+  let t = pkgConfigContents("llvm") ??
+    fatalError("Didn't find llvm.pc in any of the locations of PKG_CONFIG_PATH.")
 
-  let libs = pkgConfigValues(in: t, for: "Libs")
-  return libs.compactMap { (lib) -> LinkerSetting? in
-    if !lib.starts(with: "-l") && (lib.first == "-") { return nil }
+  do {
+    let libs = try pkgConfigValues(in: t, for: "Libs")
+    return libs.compactMap { (lib) -> LinkerSetting? in
+      if !lib.starts(with: "-l") && (lib.first == "-") { return nil }
 
-    let rest = lib.dropFirst(lib.first == "-" ? 2 : 0)
-    let afterSlashes = rest.lastIndex(where: { $0 == "/" || $0 == "\\" })
-      .map { rest.index(after: $0) } ?? rest.startIndex
+      let rest = lib.dropFirst(lib.first == "-" ? 2 : 0)
+      let afterSlashes = rest.lastIndex(where: { $0 == "/" || $0 == "\\" })
+        .map { rest.index(after: $0) } ?? rest.startIndex
 
-    let s = rest[afterSlashes...].droppingSuffix(".lib")
-    return LinkerSetting.linkedLibrary(String(s))
+      let s = rest[afterSlashes...].droppingSuffix(".lib")
+      return LinkerSetting.linkedLibrary(String(s))
+    }
+  } catch {
+    fatalError("Failed to acquire pkg-config values. Error: \(error)")
   }
 }
 
 /// Returns the path to an executable named `name` or `name.exe` if one can be found at one of the
 /// locations in the PATH environment variable; otherwise, returns `nil`.
 func findExecutableOnPath(name: String) -> String? {
-  guard let path = ProcessInfo.processInfo.environment["PATH"] else { 
-    fatalError("No PATH environment variable found")
-  }
+  let path = ProcessInfo.processInfo.environment["PATH"] 
+    ?? fatalError("No PATH environment variable found")
+
   let executableFileName = osIsWindows ? "\(name).exe" : name
 
   let locations = path.split(separator: pathSeparator)
@@ -123,18 +137,28 @@ func findExecutableOnPath(name: String) -> String? {
 }
 
 /// Returns the contents written to the standard output by `executable` ran with `arguments`.
-func readProcessOutput(executable: String, arguments: [String]) -> String {
+func readProcessOutput(executable: String, arguments: [String]) -> String? {
   let process = Process()
   process.executableURL = URL(fileURLWithPath: executable)
   process.arguments = arguments
 
   let pipe = Pipe()
   process.standardOutput = pipe
-  try! process.run()
+  do {
+    try process.run()
+  } catch {
+    print("Failed to run process. Error: \(error)")
+    return nil
+  }
   process.waitUntilExit()
 
+  guard process.terminationStatus == 0 else {
+    print("Process terminated with status \(process.terminationStatus)")
+    return nil
+  }
+
   let data = pipe.fileHandleForReading.readDataToEndOfFile()
-  return String(data: data, encoding: .utf8)!
+  return String(data: data, encoding: .utf8) ?? fatalError("Failed to read process output")
 }
 
 /// Returns the flags for linking zstd on macOS.
@@ -147,12 +171,30 @@ func readProcessOutput(executable: String, arguments: [String]) -> String {
 /// libzstd.pc contains a non-architecture specific library directory on Linux.
 /// See https://github.com/facebook/zstd/issues/4488
 ///
-/// The returned flaga are only needed on macOS. Windows and Linux link zstd already.
+/// The returned flags are only needed on macOS. Windows and Linux link zstd already.
 func zstdLinkerFlagsForMacOS() -> String {
-  let r =  readProcessOutput(
-    executable: findExecutableOnPath(name: "pkg-config")!,
-    arguments: ["libzstd", "--libs-only-L"])
-  return r.trimmingCharacters(in: .whitespacesAndNewlines)
+  if let executable = findExecutableOnPath(name: "pkg-config"),
+    let ls = readProcessOutput(
+      executable: executable,
+      arguments: ["libzstd", "--libs-only-L"])
+  {
+    return ls.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  // Fallback: search common directories where zstd may be installed.
+  let commonPaths = [
+    "/opt/local/lib",  // MacPorts
+    "/opt/homebrew/lib",  // Homebrew (Apple Silicon)
+    "/usr/local/lib",  // Homebrew (Intel)
+  ]
+  for path in commonPaths {
+    if FileManager.default.fileExists(atPath: "\(path)/libzstd.dylib")
+      || FileManager.default.fileExists(atPath: "\(path)/libzstd.a")
+    {
+      return "-L\(path)"
+    }
+  }
+  fatalError("Failed to find zstd library both via pkg-config and common paths.")
 }
 
 let llvmLinkerSettings =

--- a/Package.swift
+++ b/Package.swift
@@ -6,9 +6,9 @@ import Foundation
 import PackageDescription
 
 #if os(Windows)
-let osIsWindows = true
+  let osIsWindows = true
 #else
-let osIsWindows = false
+  let osIsWindows = false
 #endif
 
 /// The text used to separate elements of the PATH environment variable.
@@ -91,11 +91,11 @@ func readProcessOutput(executable: String, arguments: [String]) -> String? {
 /// The returned flags are only needed on macOS. Windows and Linux link zstd already.
 func zstdLinkerFlagsForMacOS() -> String {
   if let executable = findExecutableOnPath(name: "pkg-config"),
-  let ls = readProcessOutput(
+  let libraries = readProcessOutput(
     executable: executable,
     arguments: ["libzstd", "--libs-only-L"])
     {
-    return ls.trimmingCharacters(in: .whitespacesAndNewlines)
+    return libraries.trimmingCharacters(in: .whitespacesAndNewlines)
   }
 
   // Fallback: search common directories where zstd may be installed.
@@ -115,9 +115,11 @@ func zstdLinkerFlagsForMacOS() -> String {
 }
 
 #if os(macOS)
-let llvmLinkerSettings: [LinkerSetting] = [.unsafeFlags([zstdLinkerFlagsForMacOS()], .when(platforms: [.macOS]))]
+  let llvmLinkerSettings: [LinkerSetting] = [
+    .unsafeFlags([zstdLinkerFlagsForMacOS()], .when(platforms: [.macOS]))
+  ]
 #else
-let llvmLinkerSettings: [LinkerSetting] = []
+  let llvmLinkerSettings: [LinkerSetting] = []
 #endif
 
 // MARK: Package manifest

--- a/Package.swift
+++ b/Package.swift
@@ -6,86 +6,13 @@ import Foundation
 import PackageDescription
 
 #if os(Windows)
-  let osIsWindows = true
+let osIsWindows = true
 #else
-  let osIsWindows = false
+let osIsWindows = false
 #endif
 
 /// The text used to separate elements of the PATH environment variable.
 let pathSeparator: Character = osIsWindows ? ";" : ":"
-
-/// Returns the contents of the pkg-config file for `package` if they can be found in
-/// `PKG_CONFIG_PATH`.
-///
-/// This function does not search the standard locations for the file as pkg-config would.
-func pkgConfigContents(_ package: String) -> String? {
-  if let p = ProcessInfo.processInfo.environment["PKG_CONFIG_PATH"] {
-    for q in p.split(separator: pathSeparator) {
-      if let s = try? String(contentsOfFile: "\(q)/\(package).pc", encoding: .utf8) { return s }
-    }
-  }
-  return nil
-}
-
-/// Returns the un-quoted, un-escaped elements in the remainder of the (logical) lines beginning
-/// with `"\(key): "` in `pcContents`, which are the contents of a pkg-config file.
-func pkgConfigValues(in pcContents: String, for key: String) throws -> [String] {
-  let keyPattern = NSRegularExpression.escapedPattern(for: key)
-  let lineHeadersPattern = #"(?m)(?<!\\[\r]?[\n])^[ \t]*"# + keyPattern + #"[ \t]*:[ \t]*"#
-  let lineHeaders = try pcContents.matches(forRegex: lineHeadersPattern).joined().compactMap { $0 }
-
-  var r: [String] = []
-  for h in lineHeaders {
-    var input = pcContents[h.endIndex...]
-
-    func add(_ c: Character) {
-      r[r.count - 1].append(c)
-    }
-
-    header: while let c = input.popFirst(), !c.isNewline {
-      switch c {
-      case "'", "\"":
-        let quote = c
-        quoting: while let c1 = input.popFirst() {
-          switch c1 {
-          case "\\":
-            if let c2 = input.popFirst() { add(c2) }
-          case quote:
-            break quoting
-          default: add(c1)
-          }
-        }
-      case "\\": if let c1 = input.popFirst() { add(c1) }
-      case _ where c.isNewline: break header
-      case _ where c.isWhitespace: break
-      case _: r[r.count - 1].append(c)
-      }
-    }
-  }
-  return r
-}
-
-extension String {
-
-  /// Returns, for each match of the valid regular expression `pattern`, the given match `groups`
-  /// in the same order in which they were passed.
-  func matches(forRegex pattern: String, groups: [Int] = [0]) throws -> [[Substring?]] {
-    let r = try NSRegularExpression(pattern: pattern)
-    return r.matches(in: self, range: NSRange(startIndex..<endIndex, in: self)).map { m in
-      groups.map { g in Range(m.range(at: g), in: self).map { self[ $0 ] } }
-    }
-  }
-
-}
-
-extension Substring {
-
-  /// Returns `prefix` if `self` is equal to `prefix + suffix`; otherwise, returns `self`.
-  func droppingSuffix(_ suffix: String) -> Substring {
-    self.hasSuffix(suffix) ? Substring(self.dropLast(suffix.count)) : self
-  }
-
-}
 
 extension Optional {
 
@@ -98,33 +25,23 @@ extension Optional {
 
 // MARK: Helpers for getting flags and other settings
 
-/// Returns the linker needed for building on Windows.
-func windowsLinkerSettings() -> [LinkerSetting] {
-  let t = pkgConfigContents("llvm") ??
-    fatalError("Didn't find llvm.pc in any of the locations of PKG_CONFIG_PATH.")
-
-  do {
-    let libs = try pkgConfigValues(in: t, for: "Libs")
-    return libs.compactMap { (lib) -> LinkerSetting? in
-      if !lib.starts(with: "-l") && (lib.first == "-") { return nil }
-
-      let rest = lib.dropFirst(lib.first == "-" ? 2 : 0)
-      let afterSlashes = rest.lastIndex(where: { $0 == "/" || $0 == "\\" })
-        .map { rest.index(after: $0) } ?? rest.startIndex
-
-      let s = rest[afterSlashes...].droppingSuffix(".lib")
-      return LinkerSetting.linkedLibrary(String(s))
-    }
-  } catch {
-    fatalError("Failed to acquire pkg-config values. Error: \(error)")
+/// Returns the value of the environment variable with given key.
+///
+/// On Windows, comparison is case-insensitive.
+func environmentEntry(forKey k: String) -> String? {
+  if osIsWindows {
+    ProcessInfo.processInfo.environment.first {
+      $0.key.caseInsensitiveCompare(k) == .orderedSame
+    }?.value
+  } else {
+    ProcessInfo.processInfo.environment[k]
   }
 }
 
 /// Returns the path to an executable named `name` or `name.exe` if one can be found at one of the
 /// locations in the PATH environment variable; otherwise, returns `nil`.
 func findExecutableOnPath(name: String) -> String? {
-  let path = ProcessInfo.processInfo.environment["PATH"] 
-    ?? fatalError("No PATH environment variable found")
+  let path = environmentEntry(forKey: "PATH") ?? fatalError("No PATH environment variable found")
 
   let executableFileName = osIsWindows ? "\(name).exe" : name
 
@@ -174,10 +91,10 @@ func readProcessOutput(executable: String, arguments: [String]) -> String? {
 /// The returned flags are only needed on macOS. Windows and Linux link zstd already.
 func zstdLinkerFlagsForMacOS() -> String {
   if let executable = findExecutableOnPath(name: "pkg-config"),
-    let ls = readProcessOutput(
-      executable: executable,
-      arguments: ["libzstd", "--libs-only-L"])
-  {
+  let ls = readProcessOutput(
+    executable: executable,
+    arguments: ["libzstd", "--libs-only-L"])
+    {
     return ls.trimmingCharacters(in: .whitespacesAndNewlines)
   }
 
@@ -189,18 +106,19 @@ func zstdLinkerFlagsForMacOS() -> String {
   ]
   for path in commonPaths {
     if FileManager.default.fileExists(atPath: "\(path)/libzstd.dylib")
-      || FileManager.default.fileExists(atPath: "\(path)/libzstd.a")
-    {
+    || FileManager.default.fileExists(atPath: "\(path)/libzstd.a")
+      {
       return "-L\(path)"
     }
   }
   fatalError("Failed to find zstd library both via pkg-config and common paths.")
 }
 
-let llvmLinkerSettings =
-  osIsWindows
-  ? windowsLinkerSettings()
-  : [.unsafeFlags([zstdLinkerFlagsForMacOS()], .when(platforms: [.macOS]))]
+#if os(macOS)
+let llvmLinkerSettings: [LinkerSetting] = [.unsafeFlags([zstdLinkerFlagsForMacOS()], .when(platforms: [.macOS]))]
+#else
+let llvmLinkerSettings: [LinkerSetting] = []
+#endif
 
 // MARK: Package manifest
 

--- a/Sources/SwiftyLLVM/Utils/String+Extensions.swift
+++ b/Sources/SwiftyLLVM/Utils/String+Extensions.swift
@@ -1,7 +1,7 @@
 extension String {
 
   /// Creates an instance calling `getter` on `llvm` to read its value.
-  init?<T>(
+  public init?<T>(
     from llvm: T,
     readingWith getter: (T, UnsafeMutablePointer<Int>?) -> UnsafePointer<CChar>?
   ) {

--- a/Tests/LLVMTests/Utils/StringTests.swift
+++ b/Tests/LLVMTests/Utils/StringTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-@testable import SwiftyLLVM
+import SwiftyLLVM
 
 final class StringTests: XCTestCase {
 


### PR DESCRIPTION
- Changed all force unwraps to `fatalError`.
- When pkg-config is not available or fails to find zstd, we search zstd on 3 most common paths.

Bonus:
- Fix correct WinSDK installation in CI
- Simplify llvm library search by producing an SPM-compatible .pc file. See https://github.com/hylo-lang/llvm-build/pull/36
- Remove testable imports so that testing in xcode works even in release builds