### PR TITLE
Fix the definition of pointer sized integers

### DIFF
--- a/Sources/SwiftyLLVM/DataLayout.swift
+++ b/Sources/SwiftyLLVM/DataLayout.swift
@@ -36,8 +36,6 @@ public struct DataLayout: ~Copyable {
     return (storageSize(of: type) + align - 1) / align * align
   }
 
-  
-
   /// The alignment of `type`'s instances in bytes as specified by the target ABI.
   /// 
   /// - Guarantees:
@@ -79,14 +77,14 @@ public struct DataLayout: ~Copyable {
     Int(LLVMPointerSize(llvm))
   }
 
-  /// An integer type with equal size to pointers in the default address space.
-  public var pointerSizedIntegerType: IntegerType.UnsafeReference {
-    .init(LLVMIntPtrType(llvm))
-  }
-
   /// The address space in which function pointers are represented.
   public var programAddressSpace: AddressSpace {
     .init(SwiftyLLVMGetProgramAddressSpace(llvm))
+  }
+
+  /// Returns an integer type with equal size to pointers in the default address space.
+  internal func pointerSizedIntegerType(in context: ContextRef) -> IntegerType.UnsafeReference {
+    .init(LLVMIntPtrTypeInContext(context.raw, llvm))
   }
 
 }

--- a/Sources/SwiftyLLVM/Module.swift
+++ b/Sources/SwiftyLLVM/Module.swift
@@ -41,6 +41,7 @@ public struct Module: ~Copyable {
     self.i32 = IntegerType.create(32, in: contextRef)
     self.i64 = IntegerType.create(64, in: contextRef)
     self.i128 = IntegerType.create(128, in: contextRef)
+    self.iptr = self.targetMachine.layout.pointerSizedIntegerType(in: contextRef)
     self.functionPointer = PointerType.create(
       inAddressSpace: .init(SwiftyLLVMGetProgramAddressSpace(LLVMGetModuleDataLayout(module))),
       in: contextRef)
@@ -482,6 +483,9 @@ public struct Module: ~Copyable {
 
   /// The 128-bit integer type.
   public let i128: IntegerType.UnsafeReference
+
+  /// An integer type with equal size to pointers in the default address space.
+  public let iptr: IntegerType.UnsafeReference
 
   // MARK: Arithmetics
 

--- a/Tests/LLVMTests/DataLayoutTests.swift
+++ b/Tests/LLVMTests/DataLayoutTests.swift
@@ -87,14 +87,6 @@ final class DataLayoutTests: XCTestCase {
     XCTAssertEqual(m.layout.pointerSize, MemoryLayout<UnsafeRawPointer>.size)
   }
 
-  func testPointerSizedIntegerType() throws {
-    let m = try Module("foo")
-
-    let intptr = m.layout.pointerSizedIntegerType
-    XCTAssertEqual(m.layout.storageSize(of: intptr), m.layout.pointerSize)
-    XCTAssertEqual(m.layout.storageSize(of: intptr), MemoryLayout<UnsafeRawPointer>.size)
-  }
-
   func testProgramAddressSpace() throws {
     let m = try Module("foo")
 

--- a/Tests/LLVMTests/ModuleTests.swift
+++ b/Tests/LLVMTests/ModuleTests.swift
@@ -19,6 +19,13 @@ final class ModuleTests: XCTestCase {
     XCTAssertNil(m.type(named: "U"))
   }
 
+  func testPointerSizedInteger() throws {
+    let m = try Module("foo")
+    let t = m.iptr
+    XCTAssertEqual(m.layout.storageSize(of: t), m.layout.pointerSize)
+    XCTAssertEqual(m.layout.storageSize(of: t), MemoryLayout<UnsafeRawPointer>.size)
+  }
+
   func testFunctionNamed() throws {
     var m = try Module("foo")
     let f = m.declareFunction("fn", m.functionType(from: ()))


### PR DESCRIPTION
Pointer sized integers are created in the default context, which is not the same as the context in which almost everything else is created.

Since a module is created with a layout, we can fix this issue by adding a property on `Module` representing intptr, next to all other integer types.