### PR TITLE
Update Swift version to 6.3

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,2 @@
 ARG HYLO_LLVM_BUILD_TYPE=MinSizeRel
-FROM ghcr.io/hylo-lang/hylo-dev-toolchain:v1.0.1-${HYLO_LLVM_BUILD_TYPE}
+FROM ghcr.io/hylo-lang/hylo-dev-toolchain:v1.0.2-${HYLO_LLVM_BUILD_TYPE}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ on:
 env:
   spm-build-options: -Xswiftc -enable-testing --explicit-target-dependency-import-check error
   spm-test-options: --parallel
-  swift-version: '6.2'
+  swift-version: '6.3'
   HYLO_LLVM_BUILD_RELEASE: 20260521-114955
   HYLO_LLVM_VERSION: '20.1.6'
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.2
+// swift-tools-version:6.3
 
 // MARK: Poor person's pkg-config processing, required to handle pkg-config files on Windows.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See also: [swift-llvm-bindings](https://github.com/apple/swift-llvm-bindings)
 
 ### Swift
 
-This package requires Swift 6.2
+This package requires Swift 6.3
 
 ### LLVM
 


### PR DESCRIPTION
The Windows CI was broken by some mismatched clang version for the C++ standard library compilation. It works again in Swift 6.3. We have not found the root cause of why the problem got introduced in the first place.