### PR TITLE
Add floating point fast math flags

### DIFF
--- a/Sources/SwiftyLLVM/FastMathFlags.swift
+++ b/Sources/SwiftyLLVM/FastMathFlags.swift
@@ -1,0 +1,69 @@
+internal import llvmc
+
+/// Fast floating point operation flags used for allowing additional optimizations.
+/// 
+/// LLVM IR floating-point operations (fneg, fadd, fsub, fmul, fdiv, frem, fcmp, fptrunc, fpext),
+/// uitofp, sitofp, and phi, select, or call instructions that return floating-point types may use
+/// the following flags to enable otherwise unsafe floating-point transformations.
+///
+/// - See: https://llvm.org/docs/LangRef.html#fast-math-flags
+public struct FastMathFlags: OptionSet, Sendable {
+
+  /// The LLVM representation of `self`.
+  public let rawValue: UInt32
+
+  /// Creates an instance from its LLVM representation.
+  public init(rawValue: UInt32) { self.rawValue = rawValue }
+
+  /// Allow algebraically equivalent transformations for floating-point instructions such as 
+  /// reassociation transformations. This may dramatically change results in floating-point.
+  public static let reassoc = FastMathFlags(rawValue: 1 << 0)
+  
+  /// Assume no NaNs.
+  /// 
+  /// Allow optimizations to assume the arguments and result are not NaN. If an argument is a NaN, 
+  /// or the result would be a NaN, it produces a poison value instead.
+  public static let nnan = FastMathFlags(rawValue: 1 << 1)
+
+  /// Assume no infinities.
+  /// 
+  /// Allow optimizations to assume the arguments and result are not `+/-Inf`. If an argument is 
+  /// `+/-Inf`, or the result would be `+/-Inf`, it produces a poison value instead.
+  public static let ninf = FastMathFlags(rawValue: 1 << 2)
+
+  /// Assume no signed zeros.
+  /// 
+  /// Unless otherwise mentioned, the sign bit of `0.0` or `-0.0` input operands can be 
+  /// non-deterministically flipped. This does not imply that `-0.0` is poison and/or guaranteed to
+  /// not exist in the operation.
+  public static let nsz = FastMathFlags(rawValue: 1 << 3)
+
+  /// Allows division to be treated as a multiplication by a reciprocal.
+  /// 
+  /// Specifically, this permits `a / b` to be considered equivalent to `a * (1.0 / b)` 
+  /// (which may subsequently be susceptible to code motion), and it also permits `a / (b / c)` to 
+  /// be considered equivalent to `a * (c / b)`. Both of these rewrites can be applied in either
+  /// direction: `a * (c / b)` can be rewritten into `a / (b / c)`.
+  public static let arcp = FastMathFlags(rawValue: 1 << 4)
+
+  /// Allow floating-point contraction.
+  /// 
+  /// E.g., fusing a multiply followed by an addition into a fused multiply-and-add.
+  /// 
+  /// This does not enable reassociation to form arbitrary contractions. For example,
+  /// `(a*b) + (c*d) + e` can not be transformed into `(a*b) + ((c*d) + e)`` to create two 
+  /// fma operations.
+  public static let contract = FastMathFlags(rawValue: 1 << 5)
+  
+  /// Approximate functions - Allow substitution of approximate calculations for math functions.
+  ///
+  /// See floating-point intrinsic definitions for places where this can apply to LLVM’s intrinsic
+  /// math functions.
+  public static let afn = FastMathFlags(rawValue: 1 << 6)
+
+  /// An instance with all flags active.
+  public static let fast: FastMathFlags = [
+    .reassoc, .nnan, .ninf, .nsz, .arcp, .contract, .afn,
+  ]
+
+}

--- a/Sources/SwiftyLLVM/Module.swift
+++ b/Sources/SwiftyLLVM/Module.swift
@@ -495,6 +495,20 @@ public struct Module: ~Copyable {
     LLVMSetAlignment(v.raw, UInt32(a))
   }
 
+  /// Sets the fast floating point flags for `i` to allow additional optimizations.
+  ///
+  /// Requires floating-point operations (fneg, fadd, fsub, fmul, fdiv, frem, fcmp, fptrunc, fpext),
+  /// uitofp, sitofp, and phi, select, or call instructions that return floating-point types.
+  /// - Note: calling this has no effect if `i` is a compile-time constant.
+  /// - See: https://llvm.org/docs/LangRef.html#fast-math-flags
+  public mutating func setFastMathFlags<I: IRInstruction>(
+    _ flags: FastMathFlags, for i: I.UnsafeReference
+  ) {
+    if !i.unsafe[].isConstant {
+      LLVMSetFastMathFlags(i.llvm.raw, flags.rawValue)
+    }
+  }
+
   /// The LLVM context of this module wrapped as a SwiftyLLVM reference.
   private var contextRef: ContextRef { .init(context) }
 

--- a/Sources/SwiftyLLVM/Values/Instructions/IRInstruction.swift
+++ b/Sources/SwiftyLLVM/Values/Instructions/IRInstruction.swift
@@ -1,3 +1,5 @@
+internal import llvmc
+
 /// An instruction in LLVM IR.
 public protocol IRInstruction: IRValue {}
 
@@ -5,5 +7,21 @@ extension IRInstruction {
 
   /// The value operands of `self`.
   public var operands: Operands { .init(of: self) }
+
+  /// The fast floating point operation flags used for allowing additional optimizations.
+  /// 
+  /// - Requires: `self` is a floating-point operation (fneg, fadd, fsub, fmul, fdiv, frem, fcmp, 
+  ///   fptrunc, fpext), uitofp, sitofp, and phi, select, or call instructions that return a
+  ///   floating-point type.
+  /// 
+  /// - Note: fast math flags don't apply to compile-time constants.
+  /// - See: https://llvm.org/docs/LangRef.html#fast-math-flags
+  public var fastMathFlags: FastMathFlags {
+    if isConstant { 
+      .init()
+    } else {
+      .init(rawValue: LLVMGetFastMathFlags(llvm.raw))
+    }
+  }
 
 }

--- a/Tests/LLVMTests/Values/Instructions/FloatingPointArithmeticTests.swift
+++ b/Tests/LLVMTests/Values/Instructions/FloatingPointArithmeticTests.swift
@@ -59,4 +59,45 @@ final class FloatingPointArithmeticTests: XCTestCase {
     XCTAssertNoThrow(try m.verify())
   }
 
+  func testFlagsRuntime() throws {
+    var m = try Module("foo", targetMachine: .host())
+    let f = m.declareFunction("f", m.functionType(from: [m.double.t], to: m.double.t))
+    let b = m.appendBlock(to: f)
+    let p0 = f.unsafe[].parameters[0]
+
+    let i = m.insertFAdd(p0, p0, at: m.endOf(b))
+
+    XCTAssertEqual(i.unsafe[].fastMathFlags, FastMathFlags())
+
+    m.setFastMathFlags([.afn, .contract], for: i)
+
+    XCTAssertEqual(i.unsafe[].fastMathFlags, [.contract, .afn])
+    XCTAssertNotEqual(i.unsafe[].fastMathFlags, .fast)
+
+    m.setFastMathFlags(.fast, for: i)
+
+    XCTAssertEqual(i.unsafe[].fastMathFlags, .fast)
+
+    m.insertReturn(i, at: m.endOf(b))
+    XCTAssertNoThrow(try m.verify())
+  }
+
+
+  func testFlagsCompileTime() throws {
+    var m = try Module("foo", targetMachine: .host())
+    let f = m.declareFunction("f", m.functionType(from: []))
+    let b = m.appendBlock(to: f)
+
+    let i = m.insertFAdd(
+      m.double.unsafe[].constant(1), 
+      m.double.unsafe[].constant(1), at: m.endOf(b))
+    XCTAssertEqual(i.unsafe[].fastMathFlags, FastMathFlags())
+
+    m.setFastMathFlags([.afn, .contract], for: i)
+    XCTAssertEqual(i.unsafe[].fastMathFlags, [])
+
+    m.insertReturn(at: m.endOf(b))
+    XCTAssertNoThrow(try m.verify())
+  }
+
 }


### PR DESCRIPTION
Required to add support for Hylo's floating point operation builtin flags in preparation of https://github.com/hylo-lang/hylo-new/issues/358