### PR TITLE
Implement a getter for natural stack alignment

### DIFF
--- a/Sources/SwiftyLLVM/DataLayout.swift
+++ b/Sources/SwiftyLLVM/DataLayout.swift
@@ -72,6 +72,11 @@ public struct DataLayout: ~Copyable {
     Int(LLVMElementAtOffset(llvm, type.llvm.raw, UInt64(offset)))
   }
 
+  /// The natural stack alignment of the target, or `nil` if it isn't specified.
+  public var stackAlignment: Int? {
+    Int(SwiftyLLVMGetStackAlignment(llvm))
+  }
+
   /// The size of pointers in bytes in the default address space.
   public var pointerSize: Int {
     Int(LLVMPointerSize(llvm))

--- a/Sources/llvmshims/include/shim.h
+++ b/Sources/llvmshims/include/shim.h
@@ -62,6 +62,9 @@ char *SwiftyLLVMGetFirstInvalidFeature(
   LLVMTargetRef target, const char *triple, const char *features
 );
 
+/// Returns the natural stack alignment, or `-1` if one wasn't specified.
+long SwiftyLLVMGetStackAlignment(LLVMTargetDataRef dataLayout);
+
 LLVM_C_EXTERN_C_END
 
 #endif

--- a/Sources/llvmshims/src/shim.cc
+++ b/Sources/llvmshims/src/shim.cc
@@ -155,4 +155,14 @@ auto SwiftyLLVMGetFirstInvalidFeature(
   return LLVMCreateMessage(llvm::SubtargetFeatures::StripFlag(*it).str().c_str());
 }
 
+long SwiftyLLVMGetStackAlignment(LLVMTargetDataRef dataLayout) {
+  llvm::DataLayout *td = llvm::unwrap(dataLayout);
+  auto n = td->getStackAlignment();
+  if (n.has_value()) {
+    return n.value().value();
+  } else {
+    return -1;
+  }
+}
+
 } // extern "C"

--- a/Tests/LLVMTests/DataLayoutTests.swift
+++ b/Tests/LLVMTests/DataLayoutTests.swift
@@ -61,9 +61,11 @@ final class DataLayoutTests: XCTestCase {
 
     XCTAssertGreaterThanOrEqual(preferredAlignment, abiAlignment)
     XCTAssertTrue(
-      preferredAlignment & (preferredAlignment - 1) == 0, "preferred alignment must be a power of 2"
-    )
-    XCTAssertTrue(abiAlignment & (abiAlignment - 1) == 0, "abi alignment must be a power of 2")
+      preferredAlignment & (preferredAlignment - 1) == 0,
+      "preferred alignment must be a power of 2")
+    XCTAssertTrue(
+      abiAlignment & (abiAlignment - 1) == 0,
+      "abi alignment must be a power of 2")
   }
 
   func testAlignmentGuarantees() throws {
@@ -78,6 +80,11 @@ final class DataLayoutTests: XCTestCase {
     assertAlignmentInvariants(m.float, in: m.layout)
     assertAlignmentInvariants(m.double, in: m.layout)
     assertAlignmentInvariants(m.fp128, in: m.layout)
+  }
+
+  func testStackAlignment() throws {
+    let m = try Module("foo", targetMachine: .host())
+    if let n = m.layout.stackAlignment { XCTAssertNotEqual(n, 0) }
   }
 
   func testPointerSize() throws {


### PR DESCRIPTION
This patch implements a getter for a target's natural stack alignment (see [llvm::DataLayout::getStackAlignment](https://llvm.org/doxygen/classllvm_1_1DataLayout.html#a9234a42689bb875b36a3025337edaa8a)).

We require a shim because `getStackAlignment` is not available in the C API of LLVM.

The test is very poor but I don't know how to reliably create an oracle. Maybe @tothambrus11 has a better idea.